### PR TITLE
Update url for opening visual tests manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To use the Material theme, import the correspondent file from the `theme/materia
 
 1. You can also open visual tests, for example:
 
-  - http://127.0.0.1:3000/test/visual/default.html
+  - http://localhost:8000/test/visual/default.html
 
 
 ## Running tests from the command line


### PR DESCRIPTION
According to the readme, you can run the project in your project with `npm install` and `npm start`. 
That works and opens the browser, pointing at http://localhost:8000/, with the docs.
Next it says that you open visual tests with http://127.0.0.1:3000/... That gives a 404. 
I updated 127.0.1:3000 to be localhost:8080, to match the URL from `npm start`.